### PR TITLE
Adding foodcritic testing

### DIFF
--- a/.foodcritic
+++ b/.foodcritic
@@ -1,0 +1,1 @@
+correctness

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -5,7 +5,7 @@ DEPENDENCIES
 
 GRAPH
   apt (3.0.0)
-  netuitive (0.1.0)
+  netuitive (0.2.0)
     apt (>= 0.0.0)
     yum (>= 0.0.0)
   yum (3.10.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
-# 0.1.1
+# Change Log
+This project adheres to [Semantic Versioning](http://semver.org/).
 
-Update to latest Netuitive-agent (0.2.3-70)
+## 0.2.0
+### Added
+- foodcritic testing
+### Changed
+- All LWRPs use `use_inline_resources` to address foodcritic ~FC057
 
-# 0.1.0
+## 0.1.1
+- Update to latest Netuitive-agent (0.2.3-70)
 
-Initial release of netuitive
+## 0.1.0
+- Initial release of netuitive

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem "test-kitchen"
 gem "kitchen-vagrant"
+gem 'foodcritic'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    erubis (2.7.0)
+    foodcritic (6.0.1)
+      erubis
+      gherkin (~> 2.11)
+      nokogiri (>= 1.5, < 2.0)
+      rake
+      rufus-lru (~> 1.0)
+      treetop (~> 1.4)
+      yajl-ruby (~> 1.1)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
+    kitchen-vagrant (0.19.0)
+      test-kitchen (~> 1.4)
+    mini_portile2 (2.0.0)
+    mixlib-install (0.7.1)
+    mixlib-shellout (2.2.6)
+    multi_json (1.11.2)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
+    net-ssh (3.0.2)
+    nokogiri (1.6.7.2)
+      mini_portile2 (~> 2.0.0.rc2)
+    polyglot (0.3.5)
+    rake (10.5.0)
+    rufus-lru (1.0.5)
+    safe_yaml (1.0.4)
+    test-kitchen (1.6.0)
+      mixlib-install (~> 0.7)
+      mixlib-shellout (>= 1.2, < 3.0)
+      net-scp (~> 1.1)
+      net-ssh (>= 2.9, < 4.0)
+      safe_yaml (~> 1.0)
+      thor (~> 0.18)
+    thor (0.19.1)
+    treetop (1.6.5)
+      polyglot (~> 0.3)
+    yajl-ruby (1.2.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  foodcritic
+  kitchen-vagrant
+  test-kitchen
+
+BUNDLED WITH
+   1.11.2

--- a/Makefile
+++ b/Makefile
@@ -7,4 +7,9 @@ rubofix:
 kitchenconverge:
 	kitchen converge
 
-test: rubotest kitchenconverge
+foodtest:
+	foodcritic .
+
+travisci: rubotest foodtest
+
+test: rubotest foodtest kitchenconverge

--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -2,6 +2,8 @@ class NetuitiveCookbook::NetuitiveConfigureProvider < Chef::Provider::LWRPBase
   include NetuitiveCookbook::Helpers
   provides :netuitive_configure
 
+  use_inline_resources
+
   action :create do
     # the default template for netuitive with your API key
     template new_resource.conf_path do

--- a/libraries/provider_install.rb
+++ b/libraries/provider_install.rb
@@ -2,6 +2,8 @@ class NetuitiveCookbook::NetuitiveInstallProvider < Chef::Provider::LWRPBase
   include NetuitiveCookbook::Helpers
   provides :netuitive_install
 
+  use_inline_resources
+
   action :install do
     package new_resource.package_name
   end

--- a/libraries/provider_repo.rb
+++ b/libraries/provider_repo.rb
@@ -2,6 +2,8 @@ class NetuitiveCookbook::NetuitiveRepoProvider < Chef::Provider::LWRPBase
   include NetuitiveCookbook::Helpers
   provides :netuitive_repo
 
+  use_inline_resources
+
   action :add do
     platform = determine_platform
     unless new_resource.version

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'me@benabrams.it'
 license          'All rights reserved'
 description      'Installs/Configures netuitive'
 long_description 'Installs/Configures netuitive'
-version          '0.1.1'
+version          '0.2.0'
 
 depends 'apt'
 depends 'yum'


### PR DESCRIPTION
Adding some basic foodcritic testing. adding some extra functions in Makefile for testing.

@Createor I created a `make travisci` that we should probably use to do testing that way its easier for people to add testing and expect it to be tested in travis.
