### PR TITLE
Fix the typo that would make relations fail to work properly.

### DIFF
--- a/templates/default/netuitive-agent.conf.erb
+++ b/templates/default/netuitive-agent.conf.erb
@@ -62,13 +62,13 @@ api_key = <%= @api_key %>
 ### Uncomment to add tags
 # tags = tag1:tag1val, tag2:tag2val
 <% unless @tags.empty? %>
-<%= "tags = #{@tags.sort.join(', ')}" %>
+tags = <%= @tags.sort.join(', ') %>
 <% end %>
 
 ### Uncomment to add relations
 # relations = element1, element2
 <% unless @relations.empty? %>
-<%= "tags = #{@relations.sort.join(', ')}" %>
+relations = <%= @relations.sort.join(', ') %>
 <% end %>
 
 # How many samples to store before sending to Netuitive


### PR DESCRIPTION
Also refactor both tags and relations so they don't use unnecessary string interpolation.
