### PR TITLE
Make DiskUsageCollector metrics whitelist configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,13 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- added `disk_usage_collector_metrics_whitelist` @ziggythehamster
+- improved README.md @ziggythehamster
 
 ## 0.13.0
 - fix typos in tags and relations @ziggythehamster
 - fix typo with logger repo provider @ziggythehamster
-- added docker_collector_enabled @ziggythehamster
+- added `docker_collector_enabled` @ziggythehamster
 
 
 ## 0.12.0

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This cookbook is meant to be consumed by wrapper cookbooks such as this: [wrappe
 
 | Key | Type | Description | Default |
 |-----|------|-------------|---------|
-| `node['netuitive']['version']` | string | The version of the agent to install | `'0.2.9-98'`|
+| `node['netuitive']['version']` | String | The version of the agent to install | `'0.2.9-98'`|
 | `node['netuitive']['repo']['urls']` | Hash | A hash of platform specific repo urls | `{ 'debian' => 'https://repos.app.netuitive.com/deb/', 'rhel' => 'https://repos.app.netuitive.com/rpm/noarch' }` |
 | `node['netuitive']['repo']['keys']` | Hash | A hash of platform specific repo gpg key locations | `{ 'debian' => 'https://repos.app.netuitive.com/netuitive.gpg', 'rhel' => 'https://repos.app.netuitive.com/RPM-GPG-KEY-netuitive' }` |
 | `node['netuitive']['repo']['components']` | Hash | A hash of platform specific compnents | `{ 'debian' => ['stable', 'main'] }` |
@@ -59,15 +59,16 @@ All recipes are simple wrappers around the lightweight resources and providers (
 ##### Attributes
 | Name | Description | Default |
 |:------:|-------------|-------------|
-| api_key | Your datasource's API key. | 'CHANGE_ME_PLZ' |
-| api_url | The API url for netuitive. | 'https://api.app.netuitive.com/ingest/infrastructure' |
-| conf_path | The path to your Netuitive agent config file. | '/opt/netuitive-agent/conf/netuitive-agent.conf' |
-| cookbook_template | Specifies a different cookbook that the template can come from. | 'netuitive' |
-| docker_collector_enabled | Whether or not to enable the Docker collector. May be `true` or `false`. | false |
-| relations | An array of relations. | [] |
-| source | The name of the template. | 'netuitive-agent.conf.erb' |
-| statsd_enabled | Whether to enable embedded statsd server. | 'False' |
-| tags | An array of tags . | [] |
+| api_key | Your datasource's API key. | `'CHANGE_ME_PLZ'` |
+| api_url | The API url for netuitive. | `'https://api.app.netuitive.com/ingest/infrastructure'` |
+| conf_path | The path to your Netuitive agent config file. | `'/opt/netuitive-agent/conf/netuitive-agent.conf'` |
+| cookbook_template | Specifies a different cookbook that the template can come from. | `'netuitive'` |
+| disk_usage_collector_metrics_whitelist | Specifies the metrics whitelist for the DiskUsageCollector. You might change this if you wanted to ignore the Docker device mapper metrics. | `'(?:^.*\.io$|^.*\.average_queue_length$|^.*\.await$|^.*\.iops$|^.*\.read_await$|^.*\.reads$|^.*\.util_percentage|^.*\.write_await$|^.*\.writes$)'` |
+| docker_collector_enabled | Whether or not to enable the Docker collector. May be `true` or `false`. | `false` |
+| relations | An array of relations. | `[]` |
+| source | The name of the template. | `'netuitive-agent.conf.erb'` |
+| statsd_enabled | Whether to enable embedded statsd server. | `'False'` |
+| tags | An array of tags . | `[]` |
 
 #### netuitive_collector
 
@@ -77,11 +78,11 @@ All recipes are simple wrappers around the lightweight resources and providers (
 ##### Attributes
 | Name | Description | Default |
 |:------:|-------------|-------------|
-| conf_path | The path to your Netuitive agent config file. | '/opt/netuitive-agent/conf/netuitive-agent.conf' |
-| cookbook_template | Specifies a different cookbook that the template can come from. | 'netuitive' |
-| collectors_dir | Dir that custom collectors live in. | '/opt/netuitive-agent/conf/collectors' |
-| custom_collectors | A hash of collectos and options to create. | {} |
-| source | The name of the template. | collector_generic.conf.erb |
+| conf_path | The path to your Netuitive agent config file. | `'/opt/netuitive-agent/conf/netuitive-agent.conf'` |
+| cookbook_template | Specifies a different cookbook that the template can come from. | `'netuitive'` |
+| collectors_dir | Dir that custom collectors live in. | `'/opt/netuitive-agent/conf/collectors'` |
+| custom_collectors | A hash of collectors and options to create. | `{}` |
+| source | The name of the template. | `'collector_generic.conf.erb'` |
 
 #### netuitive_install
 
@@ -91,7 +92,7 @@ All recipes are simple wrappers around the lightweight resources and providers (
 ##### Attributes
 | Name | Description | Default |
 |:------:|-------------|-------------|
-| package_name | The package's name. | 'netuitive-agent' |
+| package_name | The package's name. | `'netuitive-agent'` |
 
 #### netuitive_repo
 
@@ -101,12 +102,12 @@ All recipes are simple wrappers around the lightweight resources and providers (
 ##### Attributes
 | Name | Description | Default |
 |:------:|-------------|-------------|
-| repo_components | A hash of platform-specific components. | nil |
-| repo_keys | A hash of platform-specific repository GPG keys. | nil |
-| repo_priority_pins | A hash of platform-specific repo pins. | nil |
-| repo_urls | A hash of platform-specific repository URLs. | nil |
-| use_epel_repos | Bool value to enable epel repos (doesnt do anything on debian based repos). | nil |
-| version | The version to pin. | nil |
+| repo_components | A hash of platform-specific components. | `nil` |
+| repo_keys | A hash of platform-specific repository GPG keys. | `nil` |
+| repo_priority_pins | A hash of platform-specific repo pins. | `nil` |
+| repo_urls | A hash of platform-specific repository URLs. | `nil` |
+| use_epel_repos | Bool value to enable EPEL repos (doesn't do anything on Debian-based repos). | `nil` |
+| version | The version to pin. | `nil` |
 
 
 Additional Information

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Netuitive Cookbook (Chef)
 
 [![Build Status](https://travis-ci.org/Netuitive/chef-netuitive.svg?branch=master)](https://travis-ci.org/Netuitive/chef-netuitive) [![Join the chat at https://gitter.im/Netuitive/chef-netuitive](https://badges.gitter.im/Netuitive/chef-netuitive.svg)](https://gitter.im/Netuitive/chef-netuitive?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/Netuitive/chef-netuitive/master/LICENSE)
 
-A cookbook to automate the installataion and configuration of the Netuitive Linux agent. For more
+A cookbook to automate the installation and configuration of the Netuitive Linux agent. For more
 information on the Netuitive Linux Agent, see the [help docs](https://help.netuitive.com/Content/Misc/Datasources/Netuitive/new_netuitive_datasource.htm) or contact Netuitive support at [support@netuitive.com](mailto:support@netuitive.com).
 
 This cookbook is meant to be consumed by wrapper cookbooks such as this: [wrapper cookbook](https://github.com/CloudCruiser/ops_chef-cc_netuitive)

--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -13,6 +13,7 @@ class NetuitiveCookbook::NetuitiveConfigureProvider < Chef::Provider::LWRPBase
       variables(
         api_key: new_resource.api_key,
         api_url: new_resource.api_url,
+        disk_usage_collector_metrics_whitelist: new_resource.disk_usage_collector_metrics_whitelist,
         docker_collector_enabled: new_resource.docker_collector_enabled,
         statsd_enabled: new_resource.statsd_enabled,
         tags: new_resource.tags,

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -9,6 +9,7 @@ class NetuitiveCookbook::NetuitiveConfigureResource < Chef::Resource::LWRPBase
   attribute(:api_url, kind_of: String, default: 'https://api.app.netuitive.com/ingest/infrastructure')
   attribute(:conf_path, kind_of: String, default: '/opt/netuitive-agent/conf/netuitive-agent.conf')
   attribute(:cookbook_template, kind_of: String, default: 'netuitive')
+  attribute(:disk_usage_collector_metrics_whitelist, kind_of: String, default: '(?:^.*\.io$|^.*\.average_queue_length$|^.*\.await$|^.*\.iops$|^.*\.read_await$|^.*\.reads$|^.*\.util_percentage|^.*\.write_await$|^.*\.writes$)')
   attribute(:docker_collector_enabled, kind_of: [TrueClass, FalseClass], default: false)
 
   # an array of relations

--- a/templates/default/netuitive-agent.conf.erb
+++ b/templates/default/netuitive-agent.conf.erb
@@ -153,7 +153,7 @@ simple = True
 
 [[DiskUsageCollector]]
 enabled = True
-metrics_whitelist = (?:^.*\.io$|^.*\.average_queue_length$|^.*\.await$|^.*\.iops$|^.*\.read_await$|^.*\.reads$|^.*\.util_percentage|^.*\.write_await$|^.*\.writes$)
+metrics_whitelist = <%= @disk_usage_collector_metrics_whitelist %>
 
 [[LoadAverageCollector]]
 enabled = True


### PR DESCRIPTION
This introduces the `disk_usage_collector_metrics_whitelist` option, which is defaulted to the current value. Users might change this value if they want to ignore Docker device mapper metrics with a different whitelist value, like `(?:^(?!iostat\.dm-).*\.io$|^(?!iostat\.dm-).*\.average_queue_length$|^(?!iostat\.dm-).*\.await$|^(?!iostat\.dm-).*\.iops$|^(?!iostat\.dm-).*\.read_await$|^(?!iostat\.dm-).*\.reads$|^(?!iostat\.dm-).*\.util_percentage|^(?!iostat\.dm-).*\.write_await$|^(?!iostat\.dm-).*\.writes$)` (thanks, Jason ;)).

Since the constant is long, this adds the following Rubocop complaint:

```
libraries/resource_configure.rb:12:81: C: Line is too long. [225/80]
  attribute(:disk_usage_collector_metrics_whitelist, kind_of: String, default: '(?:^.*\.io$|^.*\.average_queue_length$|^.*\.await$|^.*\.iops$|^.*\.read_await$|^.*\.reads$|^.*\.util_percentage|^.*\.write_await$|^.*\.writes$)')
                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

Shortening that line would only make things more confusing, so I left it as is. 