### PR TITLE
Add statsd configuration options to netuitive_configure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- added `statsd_forward`, `statsd_forward_ip`, `statsd_forward_port`, `statsd_listen_ip`, and `statsd_listen_port` options to `netuitive_configure` @ziggythehamster
 
 # 0.14.0
 - added `disk_usage_collector_metrics_whitelist` @ziggythehamster

--- a/README.md
+++ b/README.md
@@ -67,7 +67,12 @@ All recipes are simple wrappers around the lightweight resources and providers (
 | docker_collector_enabled | Whether or not to enable the Docker collector. May be `true` or `false`. | `false` |
 | relations | An array of relations. | `[]` |
 | source | The name of the template. | `'netuitive-agent.conf.erb'` |
-| statsd_enabled | Whether to enable embedded statsd server. | `'False'` |
+| statsd_enabled | Whether to enable embedded statsd server. Specify the string `'True'` or `'False'` | `'False'` |
+| statsd_forward | Whether or not to forward stats from the embedded statsd server. May be `true` or `false` | `false`
+| statsd_forward_ip | The IP to forward statsd data to if forwarding is enabled. | `'127.0.0.1'`
+| statsd_forward_port | The port to forward statsd data to if forwarding is enabled. | `9125`
+| statsd_listen_ip | The interface to listen on if statsd is enabled. | `'127.0.0.1'`
+| statsd_listen_port | The port the embedded statsd listens on | `8125` |
 | tags | An array of tags . | `[]` |
 
 #### netuitive_collector

--- a/libraries/provider_configure.rb
+++ b/libraries/provider_configure.rb
@@ -16,6 +16,11 @@ class NetuitiveCookbook::NetuitiveConfigureProvider < Chef::Provider::LWRPBase
         disk_usage_collector_metrics_whitelist: new_resource.disk_usage_collector_metrics_whitelist,
         docker_collector_enabled: new_resource.docker_collector_enabled,
         statsd_enabled: new_resource.statsd_enabled,
+        statsd_forward: new_resource.statsd_forward,
+        statsd_forward_ip: new_resource.statsd_forward_ip,
+        statsd_forward_port: new_resource.statsd_forward_port,
+        statsd_listen_ip: new_resource.statsd_listen_ip,
+        statsd_listen_port: new_resource.statsd_listen_port,
         tags: new_resource.tags,
         relations: new_resource.relations
       )

--- a/libraries/resource_configure.rb
+++ b/libraries/resource_configure.rb
@@ -15,7 +15,15 @@ class NetuitiveCookbook::NetuitiveConfigureResource < Chef::Resource::LWRPBase
   # an array of relations
   attribute(:relations, kind_of: Array, default: [])
   attribute(:source, kind_of: String, default: 'netuitive-agent.conf.erb')
+
+  # statsd attributes
   attribute(:statsd_enabled, kind_of: String, default: 'False')
+  attribute(:statsd_forward, kind_of: [TrueClass, FalseClass], default: false)
+  attribute(:statsd_forward_ip, kind_of: String, default: '127.0.0.1')
+  attribute(:statsd_forward_port, kind_of: Integer, default: 9125)
+  attribute(:statsd_listen_ip, kind_of: String, default: '127.0.0.1')
+  attribute(:statsd_listen_port, kind_of: Integer, default: 8125)
+
   # the array needs to be a list of strings with 'tagName:tagVal'
   attribute(:tags, kind_of: Array, default: [])
 end

--- a/templates/default/netuitive-agent.conf.erb
+++ b/templates/default/netuitive-agent.conf.erb
@@ -82,12 +82,12 @@ trim_backlog_multiplier = 4
 
 # local statsd server
 [[[statsd]]]
-enabled = <%= @statsd_enabled %>
-# listen_port = 8125
-# listen_ip = 127.0.0.1
-# forward_ip = 127.0.0.1
-# forward_port = 9125
-# forward = False
+enabled = <% @statsd_enabled %>
+listen_port = <%= @statsd_listen_port %>
+listen_ip = <%= @statsd_listen_ip %>
+forward_ip = <%= @statsd_forward_ip %>
+forward_port = <%= @statsd_forward_port %>
+forward = <% if @statsd_forward %>True<% else %>False<% end %>
 
 ################################################################################
 ### Options for collectors


### PR DESCRIPTION
This PR adds support for configuring statsd attributes other than statsd_enabled.