### PR TITLE
Fix statsd template bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+- added `statsd_forward`, `statsd_forward_ip`, `statsd_forward_port`, `statsd_listen_ip`, and `statsd_listen_port` options to `netuitive_configure` @ziggythehamster
 
 # 0.15.0
 - added `statsd_forward`, `statsd_forward_ip`, `statsd_forward_port`, `statsd_listen_ip`, and `statsd_listen_port` options to `netuitive_configure` @ziggythehamster

--- a/templates/default/netuitive-agent.conf.erb
+++ b/templates/default/netuitive-agent.conf.erb
@@ -82,7 +82,7 @@ trim_backlog_multiplier = 4
 
 # local statsd server
 [[[statsd]]]
-enabled = <% @statsd_enabled %>
+enabled = <%= @statsd_enabled %>
 listen_port = <%= @statsd_listen_port %>
 listen_ip = <%= @statsd_listen_ip %>
 forward_ip = <%= @statsd_forward_ip %>


### PR DESCRIPTION
I inadvertently removed a `=` from the template, which broke `[[statsd]]`'s `enabled` option. Whoops.