### PR TITLE
some cleanup/housekeeping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,7 @@ deploy:
   provider: chef-supermarket
   user_id: metricly
   client-key: client.pem
+  cookbook_name: netuitive
   cookbook_category: Others
   on:
     tags: true

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,9 +3,15 @@
 name             'netuitive'
 maintainer       'Ben Abrams'
 maintainer_email 'me@benabrams.it'
-license          'All rights reserved'
+license          'MIT'
 description      'Installs/Configures netuitive'
 long_description 'Installs/Configures netuitive'
+
+# TODO: drop chef 12 support, chef 13 is about to be EOL
+chef_version     '>= 12.5' if respond_to?(:chef_version)
+issues_url       'https://github.com/Netuitive/chef-netuitive/issues' if respond_to?(:issues_url)
+source_url       'https://github.com/Netuitive/chef-netuitive' if respond_to?(:source_url)
+
 version          '0.21.0'
 
 depends 'apt'


### PR DESCRIPTION
I noticed that the travis deploy setup was not properly picking up the cookbook name so I set it explicitly.

Added and updated some other misc stuff in the metadata to match reality (for example the LICENSE in repo was MIT but the attribute in metadata said all rights reserved), chef version support, issue url, source code url, etc.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://travis-ci.org/Netuitive/chef-netuitive/jobs/505025901#L1176 motivated me and I noticed some other small nitpicks that I wanted to cleanup/fix.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Minor housekeeping

#### Known Compatibility Issues
actually enforces versions we actually support this should help users know what versions they can use and have code enforce it rather than expecting that they will actually review the `README.md`.